### PR TITLE
Correção para validação de IE para UF RO quando o mod retorna 0

### DIFF
--- a/validator_test.go
+++ b/validator_test.go
@@ -1567,6 +1567,20 @@ func TestValidatorROValid14Digits(t *testing.T) {
 	assert.True(t, result)
 }
 
+func TestValidatorROValid14DigitsMod0(t *testing.T) {
+
+	validator := NewIEValidator()
+
+	validator.IE = "00000000123421" // Valido
+	validator.UF = validators.RO
+
+	result, err := validator.Validate()
+	if err != nil {
+		t.Error("Erro na validacao do estado de Rondonia")
+	}
+	assert.True(t, result)
+}
+
 func TestValidatorROInvalid(t *testing.T) {
 
 	validator := NewIEValidator()

--- a/validators/ro.go
+++ b/validators/ro.go
@@ -1,21 +1,39 @@
 package validators
 
+import (
+	"fmt"
+	"math"
+)
+
+const moduleDivisor = 11
+
 // Rondonia struct - Rondônia
 // Implements the Validator interface
 type Rondonia struct {
+	rule *Rules
+}
+
+func (v Rondonia) getRule() Rules {
+
+	if v.rule == nil {
+		r := NewRule()
+		v.rule = &r
+	}
+
+	return *v.rule
 }
 
 // IsValid func
 func (v Rondonia) IsValid(insc string) bool {
 
-	rule := NewRule()
+	rule := v.getRule()
 
 	if rule.IsCorrectSize(insc, 9) {
 
 		base := insc[3:8]
 		weights := rule.GetWeight(6, 5)
 		total := rule.CalculateTotal(base, 5, weights)
-		var digit = rule.GetDigit(total, 11)
+		var digit = rule.GetDigit(total, moduleDivisor)
 
 		return insc == insc[:8]+digit
 
@@ -25,11 +43,29 @@ func (v Rondonia) IsValid(insc string) bool {
 
 		weights := rule.GetWeight(6, 13)
 		total := rule.CalculateTotal(insc, 13, weights)
-		var digit = rule.GetDigit(total, 11)
+		var digit = v.getDigit(total, moduleDivisor)
 
-		return insc == base+digit
+		return insc == fmt.Sprintf("%s%d", base, digit)
 
 	} else {
 		return false
 	}
+}
+
+func (v Rondonia) getDigit(total, divisor int) int {
+	rule := v.getRule()
+
+	var digit = 0
+
+	mod := rule.CalculateMod(total, divisor)
+
+	result := divisor - mod
+
+	if result >= 10 {
+		result -= 10
+	}
+
+	digit = int(math.Abs(float64(result)))
+
+	return digit
 }


### PR DESCRIPTION
fix[IE RO]: Correção na validação de IR para UF RO quando o resulta do módulo é igual a zero